### PR TITLE
Fix chunk_size being limited to 64

### DIFF
--- a/pp_root_node.gd
+++ b/pp_root_node.gd
@@ -25,7 +25,7 @@ var game_id = ''
 var logged_in = false
 var registered_entities = []
 var registered_chunks = []
-@export_range(64, 64, 65536) var Chunk_Size: int = 64
+@export_range(64, 65536) var Chunk_Size: int = 64
 
 var csproj_reference_exists = false
 var client = PPHTTPClient.new()


### PR DESCRIPTION
`@export_range`'s arguments is `min`, `max`, `step_size`. The default value is taken from the assignment. As this is an integer, we don't need to provide a step size and can use the two argument variant

https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_exports.html#limiting-editor-input-ranges