### PR TITLE
Renamed eventCallback to server_to_client

### DIFF
--- a/SDKNode.cs
+++ b/SDKNode.cs
@@ -17,13 +17,13 @@ public partial class SDKNode : Node
 	
 	public void SetEventCallback(GodotObject callbackObject)
 	{
-		if (callbackObject != null && callbackObject.HasMethod("eventCallback"))
+		if (callbackObject != null && callbackObject.HasMethod("server_to_client"))
 		{
 			GD.Print("Registered eventCallback");
 
 			this.eventCallback = (Dictionary<string, object> data) =>
 			{
-				callbackObject.Call("eventCallback", ConvertToGodotVariantDictionary(data));
+				callbackObject.Call("server_to_client", ConvertToGodotVariantDictionary(data));
 			};
 		}
 		else

--- a/pp_root_node.gd
+++ b/pp_root_node.gd
@@ -34,7 +34,7 @@ var registered_chunks = []
 # Entities: 
 @export var scenes: Array[PackedScene] = []
 # event callback
-@export var eventCallback: Node
+@export var server_to_client_node: Node
 
 var scenes_map: Dictionary = {}
 
@@ -69,11 +69,11 @@ func _ready():
 	
 	sdk_node = SDKScript.new()
 	
-	if eventCallback and eventCallback.has_method("eventCallback"):
-		print("got eventCallback")
-		sdk_node.SetEventCallback(eventCallback)
+	if server_to_client_node and server_to_client_node.has_method("server_to_client"):
+		print("got server_to_client")
+		sdk_node.SetEventCallback(server_to_client_node)
 	else:
-		print("Assigned node does not have 'eventCallback' method.")
+		print("Assigned node does not have 'server_to_client' method.")
 	
 	sdk_node.SetGameID(game_id)
 	


### PR DESCRIPTION
Renamed eventCallback to be server_to_client, so as not to be confused with serverside events (https://docs.planetaryprocessing.io/server/events) and to help clarify its purpose: a manual message from game server to client.